### PR TITLE
refactor: unify environment variables to be the same if used by docker compose and locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,12 @@ cd app
 ```
 
 ### Usage with Docker
-Create a .env file at the root of the project with the environment variables mentioned in the "For docker-compose deployment" section of the app/.env.example file
 
-Launch the bot container at the root of the project:
+1. Create a `.env` file at the root of the project with the environment variables mentioned in [app/.env.example](./app/.env.example), including those mentionned in the *"For docker-compose deployment"* section
+
+2. Launch the bot container at the root of the project:
 ```bash
-docker compose .env up --detach
+docker compose up --detach
 ```
 
 ### Troubleshooting

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cd app
 
 ### Utilisation avec Docker
 
-1. Créez un fichier `.env` à la racine du projet avec les variables d'environnement mentionnées dans la section *"For docker-compose deployment"* du fichier [app/.env.example](./app/.env.example)
+1. Créez un fichier `.env` à la racine du projet avec les variables d'environnement mentionnées dans [app/.env.example](./app/.env.example) y compris celles mentionnées dans la section *"For docker-compose deployment"*
 
 2. Lancer le container du bot à la racine du projet :
 ```bash

--- a/app/.env.example
+++ b/app/.env.example
@@ -6,15 +6,13 @@
 # For local deployment
 VERBOSE=False
 SYSTEMD_LOGGING=True
-matrix_home_server="https://matrix.agent.ministere_example.tchap.gouv.fr"
-matrix_bot_username="jean.quidam@ministere_example.gouv.fr"
-matrix_bot_password="test"
-groups_used='["basic", "albert"]'
-salt=b"\xce,\xa1\xc6lY\x80\xe3X}\x91\xa60m\xa8N"
+MATRIX_HOME_SERVER="https://matrix.agent.ministere_example.tchap.gouv.fr"
+MATRIX_BOT_USERNAME="jean.quidam@ministere_example.gouv.fr"
+MATRIX_BOT_PASSWORD="test"
+GROUPS_USED='["basic", "albert"]'
+SALT=b"\xce,\xa1\xc6lY\x80\xe3X}\x91\xa60m\xa8N"
 ## Albert env variables
-albert_api_url="https://albert-server-url.example.com"
-albert_api_token="INSERT_YOUR_TOKEN"
-albert_api_model_name="AgentPublic/guillaumetell-7b"
-user_allowed_domains='["ministere_example.gouv.fr", "ministere_example2.gouv.fr"]'
-## CI/CD env variables
-CI_DEPLOY_HOST=
+ALBERT_API_URL="https://albert-server-url.example.com"
+ALBERT_API_TOKEN="INSERT_YOUR_TOKEN"
+ALBERT_API_MODEL_NAME="AgentPublic/guillaumetell-7b"
+USER_ALLOWED_DOMAINS='["ministere_example.gouv.fr", "ministere_example2.gouv.fr"]'

--- a/app/.env.example
+++ b/app/.env.example
@@ -15,13 +15,6 @@ salt=b"\xce,\xa1\xc6lY\x80\xe3X}\x91\xa60m\xa8N"
 albert_api_url="https://albert-server-url.example.com"
 albert_api_token="INSERT_YOUR_TOKEN"
 user_allowed_domains='["ministere_example.gouv.fr", "ministere_example2.gouv.fr"]'
-
-# For docker-compose deployment 
-MATRIX_HOME_SERVER=
-MATRIX_BOT_USERNAME=
-MATRIX_BOT_PASSWORD=
-SALT=
-ALBERT_API_URL=
-ALBERT_API_TOKEN=
-USER_ALLOWED_DOMAINS='["ministere_example.gouv.fr", "ministere_example2.gouv.fr"]'
+## CI/CD env variables
 COMPOSE_PROJECT_NAME=tchap-bot
+CI_DEPLOY_HOST=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,15 +10,15 @@ services:
     environment:
       - VERBOSE=true
       - SYSTEMD_LOGGING=True
-      - matrix_home_server=${MATRIX_HOME_SERVER}
-      - matrix_bot_username=${MATRIX_BOT_USERNAME}
-      - matrix_bot_password=${MATRIX_BOT_PASSWORD}
+      - matrix_home_server=${matrix_home_server}
+      - matrix_bot_username=${matrix_bot_username}
+      - matrix_bot_password=${matrix_bot_password}
       - session_path=/data/session.txt
       - groups_used=["basic", "albert"]
-      - user_allowed_domains=${USER_ALLOWED_DOMAINS}
-      - salt=${SALT}
-      - albert_api_url=${ALBERT_API_URL}
-      - albert_api_token=${ALBERT_API_TOKEN}
+      - user_allowed_domains=${user_allowed_domains}
+      - salt=${salt}
+      - albert_api_url=${albert_api_url}
+      - albert_api_token=${albert_api_token}
     ports:
       - 443:443
       - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,16 +10,16 @@ services:
     environment:
       - VERBOSE=true
       - SYSTEMD_LOGGING=True
-      - matrix_home_server=${matrix_home_server}
-      - matrix_bot_username=${matrix_bot_username}
-      - matrix_bot_password=${matrix_bot_password}
-      - session_path=/data/session.txt
-      - groups_used=["basic", "albert"]
-      - user_allowed_domains=${user_allowed_domains}
-      - salt=${salt}
-      - albert_api_url=${albert_api_url}
-      - albert_api_token=${albert_api_token}
-      - albert_api_model_name=${albert_api_model_name}
+      - MATRIX_HOME_SERVER=${MATRIX_HOME_SERVER}
+      - MATRIX_BOT_USERNAME=${MATRIX_BOT_USERNAME}
+      - MATRIX_BOT_PASSWORD=${MATRIX_BOT_PASSWORD}
+      - SESSION_PATH=/data/session.txt
+      - GROUPS_USED=["basic", "albert"]
+      - USER_ALLOWED_DOMAINS=${USER_ALLOWED_DOMAINS}
+      - SALT=${salt}
+      - ALBERT_API_URL=${ALBERT_API_URL}
+      - ALBERT_API_TOKEN=${ALBERT_API_TOKEN}
+      - ALBERT_API_MODEL_NAME=${ALBERT_API_MODEL_NAME}
     ports:
       - 443:443
       - 80:80


### PR DESCRIPTION
Unify environment variables to be the same if used by docker compose and locally, to simplify env management.

To avoid duplicate env vars, we use the same env vars that are used by Docker compose and when run outside of Docker compose.

This will need to update the environment vars in the CI/CD settings of the CI/CD runners.

Let me know if that makes sense @dtrckd @leoguillaume 