### PR TITLE
feat: config.join_on_invite as a env variable

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -59,6 +59,7 @@ jobs:
           echo MATRIX_BOT_PASSWORD=${{ secrets.MATRIX_BOT_PASSWORD }} >> .env
           echo ERRORS_ROOM_ID=${{ secrets.ERRORS_ROOM_ID }} >> .env
           echo USER_ALLOWED_DOMAINS=${{ secrets.USER_ALLOWED_DOMAINS }} >> .env
+          echo JOIN_ON_INVITE=${{ secrets.JOIN_ON_INVITE }} >> .env
           echo SALT=${{ secrets.SALT }} >> .env
           echo ALBERT_API_URL=${{ secrets.ALBERT_API_URL }} >> .env
           echo ALBERT_API_TOKEN=${{ secrets.ALBERT_API_TOKEN }} >> .env

--- a/app/.env.example
+++ b/app/.env.example
@@ -10,6 +10,7 @@ MATRIX_BOT_USERNAME="jean.quidam@ministere_example.gouv.fr"
 MATRIX_BOT_PASSWORD="test"
 ERRORS_ROOM_ID="!aaaaaaaaa:agent.ministere_example.tchap.gouv.fr"
 GROUPS_USED='["basic", "albert"]'
+JOIN_ON_INVITE=True
 SALT=b"\xce,\xa1\xc6lY\x80\xe3X}\x91\xa60m\xa8N"
 ALBERT_API_URL="https://albert-server-url.example.com"
 ALBERT_API_TOKEN="INSERT_YOUR_TOKEN"

--- a/app/matrix_bot/config.py
+++ b/app/matrix_bot/config.py
@@ -41,7 +41,7 @@ class BotLibConfig(BaseSettings):
     model_config = SettingsConfigDict(env_file=Path(".matrix_bot_env"))
 
 
-bot_lib_config = BotLibConfig(join_on_invite=False)
+bot_lib_config = BotLibConfig()
 structlog.configure(
     wrapper_class=structlog.make_filtering_bound_logger(bot_lib_config.log_level),
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - SESSION_PATH=/data/session.txt
       - GROUPS_USED=["basic", "albert"]
       - USER_ALLOWED_DOMAINS=${USER_ALLOWED_DOMAINS}
+      - JOIN_ON_INVITE=${JOIN_ON_INVITE}
       - SALT=${SALT}
       - ALBERT_API_URL=${ALBERT_API_URL}
       - ALBERT_API_TOKEN=${ALBERT_API_TOKEN}


### PR DESCRIPTION
Add `JOIN_ON_INVITE` environment variable, to determine if the bot would automatically join a room created by the user or not.

Note: the GitHub Actions secrets have already been created and configured accordingly for staging and prod.