### PR TITLE
feat: reset message as notice format

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -152,7 +152,7 @@ async def albert_reset(ep: EventParser, matrix_client: MatrixClient):
     if config.albert_with_history:
         config.albert_chat_id = new_chat(config)
         reset_message = "La conversation a été remise à zéro."
-        await matrix_client.send_text_message(ep.room.room_id, reset_message)
+        await matrix_client.send_text_message(ep.room.room_id, reset_message, msgtype="m.notice")
         await matrix_client.send_markdown_message(
             ep.room.room_id, command_registry.get_help(config)
         )


### PR DESCRIPTION
Tested, looks like this:

![Screenshot 2024-05-29 at 17 23 05](https://github.com/etalab-ia/albert-tchapbot/assets/4353767/a4fc331c-13e1-449c-9906-faa4e42d85e7)
