### PR TITLE
feat: use regex to match sender domain

### DIFF
--- a/app/matrix_bot/eventparser.py
+++ b/app/matrix_bot/eventparser.py
@@ -52,7 +52,7 @@ class EventParser:
     def sender_username(self) -> str:
         return self.room.users[self.event.sender].name
 
-    def sender_domain(self) -> str:
+    def sender_domain(self) -> str | None:
         """
         Sender IDs are formatted like this: "@<mail_username>-<mail_domain>:<matrix_server>
         e.g. @john.doe-ministere_example.gouv.fr1:agent.ministere_example.tchap.gouv.fr
@@ -62,6 +62,7 @@ class EventParser:
         )  # match the domain name (between the first "-" and ":", with optional numbers to ignore at the end)
         if match:
             return match.group(0)
+        logger.warning("Could not extract domain from sender ID", sender_id=self.sender_id)
 
     def do_not_accept_own_message(self) -> None:
         """

--- a/app/matrix_bot/eventparser.py
+++ b/app/matrix_bot/eventparser.py
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2024 Etalab <etalab@modernisation.gouv.fr>
 #
 # SPDX-License-Identifier: MIT
+import re
 from dataclasses import dataclass
 
 from config import env_config
@@ -54,9 +55,13 @@ class EventParser:
     def sender_domain(self) -> str:
         """
         Sender IDs are formatted like this: "@<mail_username>-<mail_domain>:<matrix_server>
-        e.g. @john-doe-ministere_example.gouv.fr:agent.ministere_example.tchap.gouv.fr
+        e.g. @john.doe-ministere_example.gouv.fr1:agent.ministere_example.tchap.gouv.fr
         """
-        return self.event.sender.split(":")[0].split("-")[-1]
+        match: re.Match[str] | None = re.search(
+            r"(?<=\-)(.*?)[0-9]*(?=\:)", self.event.sender
+        )  # match the domain name (between the first "-" and ":", with optional numbers to ignore at the end)
+        if match:
+            return match.group(0)
 
     def do_not_accept_own_message(self) -> None:
         """


### PR DESCRIPTION
Some people at DINUM couldn't use the beta bot because they had a Tchap username with a domain finishing in `ministere.gouv.fr1`.

Related to https://github.com/etalab-ia/albert-tchapbot/issues/49